### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.1
+
+- Feat: New 'Count' method that allows the counting of how many rows are in a table, how many not null columns, distinct values of a column and set a custom name for the count key in the result object.
+
+- Fix(types): Fix typing mistake that caused an regression forcing an object to be passed to 'Select' and 'Find', calling those methods without any argument will behave the same way as passing an empty object, this is a typing only mistake, that doesn't change how the methods behave or parse its parameters.
+
 # v1.2.0
 
 - Feat: 'Select' and 'Find' methods can now receive an orderBy parameter to order return the results from the database

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promiseorm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promiseorm",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "GPL-3.0",
       "dependencies": {
         "mariadb": "3.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promiseorm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Typescript ORM for automatic creation and management of models and entries from simple objects",
   "main": "build/index.js",
   "files": [

--- a/src/main/connection/DatabaseConnection.ts
+++ b/src/main/connection/DatabaseConnection.ts
@@ -1,4 +1,4 @@
-import { IDatabaseConnectionRead, IDatabaseField, IDatabaseQueryFilterExpression } from '../interfaces';
+import { IDatabaseConnectionRead, IDatabaseCount, IDatabaseField, IDatabaseQueryFilterExpression } from '../interfaces';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DatabaseException } from '../errors';
 import { BaseModel } from '../models';
@@ -112,4 +112,14 @@ export abstract class DatabaseConnection {
    * @abstract
    */
   public abstract createOrUpdateTable(tableName: string, fields: Record<string, IDatabaseField>): Promise<void>
+
+  /**
+   * Returns the count of the provided fields
+   * @param fields Array of objects that specify the columns to count, if the count should be distinct, and optionally to what name rename the column of the count
+   * @param filter The filter to apply to the records
+   * @returns A promise containing an object with the count of all the requested fields
+   * @throws [{@link DatabaseException}]
+   * @abstract
+   */
+  public abstract count(database: string, { fields, filter }: { fields: IDatabaseCount[], filter?: IDatabaseQueryFilterExpression }): Promise<Record<string, number>>
 }

--- a/src/main/interfaces/connection/index.ts
+++ b/src/main/interfaces/connection/index.ts
@@ -1,2 +1,2 @@
-export * from './mariadb';
 export * from './IDatabaseConnectionRead';
+export * from './mariadb';

--- a/src/main/interfaces/database/IDatabaseCount.ts
+++ b/src/main/interfaces/database/IDatabaseCount.ts
@@ -1,0 +1,5 @@
+export interface IDatabaseCount {
+  key: string;
+  distinct: boolean;
+  alias?: string;
+};

--- a/src/main/interfaces/database/index.ts
+++ b/src/main/interfaces/database/index.ts
@@ -3,4 +3,5 @@ export * from './EDatabaseQueryFilterOperator';
 export * from './IDatabaseQueryFilter';
 export * from './IDatabaseOrderBy';
 export * from './IDatabaseField';
+export * from './IDatabaseCount';
 export * from './EDatabaseTypes';


### PR DESCRIPTION
- Feat: New 'Count' method that allows the counting of how many rows are in a table, how many not null columns, distinct values of a column and set a custom name for the count key in the result object.

- Fix(types): Fix typing mistake that caused an regression forcing an object to be passed to 'Select' and 'Find', calling those methods without any argument will behave the same way as passing an empty object, this is a typing only mistake, that doesn't change how the methods behave or parse its parameters.