### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,51 +1,60 @@
+# v1.2.2
+
+- Fix: Wrong data return behavior on 'Create' and 'Upsert' methods due to different versions of MariaDB.
+
+- Fix: Incorrectly checking of MariaDB's version, that caused misbehavior on major versions of MariaDB equal or superior to 11 if the minor version was less than 5.
+
+- Fix(typo): Improved non-null check message, fixed orthography and added more context to the error.
+
 # v1.2.1
 
 - Feat: New 'Count' method that allows the counting of how many rows are in a table, how many not null columns, distinct values of a column and set a custom name for the count key in the result object.
 
-- Fix(types): Fix typing mistake that caused an regression forcing an object to be passed to 'Select' and 'Find', calling those methods without any argument will behave the same way as passing an empty object, this is a typing only mistake, that doesn't change how the methods behave or parse its parameters.
+- Fix(types): Fix typing mistake that caused an regression forcing an object to be passed to 'Find', calling this method without any argument will behave the same way as passing an empty object.
+  - This is a typing only mistake, that doesn't change how the method behave or parse its parameters.
 
 # v1.2.0
 
-- Feat: 'Select' and 'Find' methods can now receive an orderBy parameter to order return the results from the database
+- Feat: 'Select' and 'Find' methods can now receive an orderBy parameter to order the return the results from the database.
 
-- BREAKING: 'Select' and 'Find' now receive an object as parameter instead of separated params
-
-- Chore: Updated dev dependencies
+- BREAKING: 'Select' and 'Find' now receive an object as parameter instead of separated params.
 
 # v1.1.1
 
-- Fix: Select with filter doesn't work if the value of the field 'value' is falsy
-- Fix(types): Small fix on timestamp and boolean types
+- Fix: Select with filter doesn't work if the value of the field 'value' is falsy.
+
+- Fix(types): Small fix on timestamp and boolean types.
 
 # v1.1.0
 
-- Feat: Better type on BaseModel creation
+- Feat: Better type on BaseModel creation.
 
-- Fix: Can't initialize orm when foreign keys are present due to wrong foreign key names
+- Fix: Can't initialize orm when foreign keys are present due to wrong foreign key names.
 
-- Fix: Multiple primary keys not being created due to wrong handling of primary key fields
+- Fix: Multiple primary keys not being created due to wrong handling of primary key fields.
 
-- Fix: Parsing of unique keys and foreign keys when updating tables
+- Fix: Parsing of unique keys and foreign keys when updating tables.
 
-- BREAKING: Changed constructor of MariaDBConnection to accept an object instead of multiple parameters
+- BREAKING: Changed constructor of MariaDBConnection to accept an object instead of multiple parameters.
 
 # v1.0.6
 
-- Fix: Can't create tables with foreign keys due to invalid syntax for ON DELETE and ON UPDATE clauses
+- Fix: Can't create tables with foreign keys due to invalid syntax for ON DELETE and ON UPDATE clauses.
 
 # v1.0.5
 
-- Fix: Can't connect to MySql instances due to missing allowPublicKeyRetrieval: true in connection options
+- Fix: Can't connect to MySql instances due to missing allowPublicKeyRetrieval: true in connection options.
 
 # v1.0.4
 
-- NOTICE: Rebranding 'promisedb' to 'promiseorm'
-- CI: Add CI
+- NOTICE: Rebranding 'promisedb' to 'promiseorm'.
+
+- CI: Add CI.
 
 # v1.0.3
 
-- Fix: Register schema not awaiting before returning
+- Fix: Register schema not awaiting before returning.
 
-- Fix: Update now returns updated row, if nothing got updated it returns undefined
+- Fix: Update now returns updated row, if nothing got updated it returns undefined.
 
-- Fix: Update now doesn't requires the whole row to be passed to be updated, and now will accept updating fields based on the passed search params
+- Fix: Update now doesn't require the whole row to be updated to be passed, and now will accept updating fields based on the passed search params.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promiseorm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promiseorm",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "mariadb": "3.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promiseorm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Typescript ORM for automatic creation and management of models and entries from simple objects",
   "main": "build/index.js",
   "files": [

--- a/src/main/connection/DatabaseConnection.ts
+++ b/src/main/connection/DatabaseConnection.ts
@@ -53,7 +53,7 @@ export abstract class DatabaseConnection {
    * @throws [{@link DatabaseException}]
    * @abstract
    */
-  public abstract create(database: string, keys: string[], values: any[]): Promise<Record<string, any>>
+  public abstract create(database: string, keys: string[], fields: string[], values: any[]): Promise<Record<string, any>>
 
   /**
    * Read records from the database
@@ -69,7 +69,7 @@ export abstract class DatabaseConnection {
   /**
    * Inserts data on database, if it already exists, updates the selected fields
    */
-  public abstract upsert(database: string, keys: string[], values: any[], updateFields: string[]): Promise<Record<string, any>>
+  public abstract upsert(database: string, keys: string[], fields: string[], values: any[], updateFields: string[]): Promise<Record<string, any>>
 
   /**
    * Update records in the database


### PR DESCRIPTION
- Fix: Wrong data return behavior on 'Create' and 'Upsert' methods due to different versions of MariaDB.

- Fix: Incorrectly checking of MariaDB's version, that caused misbehavior on major versions of MariaDB equal or superior to 11 if the minor version was less than 5.

- Fix(typo): Improved non-null check message, fixed orthography and added more context to the error.